### PR TITLE
MAX-11305 Fix loading spinner stuck issue

### DIFF
--- a/demo/px-spinner-demo.html
+++ b/demo/px-spinner-demo.html
@@ -110,7 +110,6 @@ limitations under the License.
     demoProps: {
       disableSvgAnimation: {
         type: Boolean,
-        inputName: 'Hide',
         defaultValue: false,
         inputType: 'toggle'
       },
@@ -120,7 +119,6 @@ limitations under the License.
         defaultValue: false,
         inputType: 'toggle'
       },
-
       size: {
         type: String,
         defaultValue: '100',

--- a/demo/px-spinner-demo.html
+++ b/demo/px-spinner-demo.html
@@ -27,13 +27,13 @@ limitations under the License.
 <link rel="import" href="../../px-demo/px-demo-component-snippet.html" />
 
 <!-- Imports for this component -->
- 
+
 <link rel="import" href="../px-spinner.html" />
 
 <!-- Demo DOM module -->
 <dom-module id="px-spinner-demo">
   <template>
- 
+
 
     <!-- Header -->
     <px-demo-header
@@ -55,7 +55,8 @@ limitations under the License.
       <px-demo-component slot="px-demo-component">
         <px-spinner
           size="{{props.size.value}}"
-          finished="{{props.finished.value}}">
+          finished="{{props.finished.value}}"
+          disable-svg-animation="{{props.disableSvgAnimation.value}}">
         </px-spinner>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
@@ -107,6 +108,12 @@ limitations under the License.
     },
 
     demoProps: {
+      disableSvgAnimation: {
+        type: Boolean,
+        inputName: 'Hide',
+        defaultValue: false,
+        inputType: 'toggle'
+      },
       finished: {
         type: Boolean,
         inputName: 'Hide',

--- a/px-spinner.html
+++ b/px-spinner.html
@@ -82,22 +82,20 @@ Custom property | Description
             value: 80,
             notify: true
           },
+          /**
+           * If set, disables SVG animations on the spinner.
+           * Set this if you need the spinner to continue animating while the event loop is blocked.
+           */
+           disableSvgAnimation: {
+            type: Boolean,
+            value: false,
+          },
           _animatedSVGSupport: {
             type: Boolean,
             readonly: true,
             value: function(){
               return Px.Modernizr.smil;
             }
-          },
-          /**
-           * This property is to control whether the spinner is rendered as svg or div element.
-           * If disableSvgAnimation is false, which is by default value, spinner is rendered as svg,
-           * otherwise the spinner is rendered as div.
-           *
-           */
-          disableSvgAnimation: {
-            type: Boolean,
-            value: false,
           },
         },
         /**

--- a/px-spinner.html
+++ b/px-spinner.html
@@ -41,13 +41,13 @@ Custom property | Description
     <style include="px-spinner-styles"></style>
 
     <template is="dom-if" if="{{!finished}}">
-      <template is="dom-if" if="{{_animatedSVGSupport}}">
+      <template is="dom-if" if="[[_shouldRenderAsSVG(_animatedSVGSupport, disableSvgAnimation)]]">
         <svg width$="{{size}}" height$="{{size}}" viewBox="0 0 100 100">
           <circle class="circle1" cx="50" cy="50" r="45" />
           <circle class="circle2" cx="50" cy="50" r="45" transform="rotate(-45,50,50)" />
         </svg>
       </template>
-      <template is="dom-if" if="{{!_animatedSVGSupport}}">
+      <template is="dom-if" if="[[!_shouldRenderAsSVG(_animatedSVGSupport, disableSvgAnimation)]]">
         <div style$="width: {{size}}px; height: {{size}}px;" class="spinner-container"></div>
       </template>
     </template>
@@ -88,7 +88,17 @@ Custom property | Description
             value: function(){
               return Px.Modernizr.smil;
             }
-          }
+          },
+          /**
+           * This property is to control whether the spinner is rendered as svg or div element.
+           * If disableSvgAnimation is false, which is by default value, spinner is rendered as svg,
+           * otherwise the spinner is rendered as div.
+           *
+           */
+          disableSvgAnimation: {
+            type: Boolean,
+            value: false,
+          },
         },
         /**
          * Shows the spinner
@@ -106,6 +116,10 @@ Custom property | Description
          */
         hide: function () {
           this.set('finished', true);
+        },
+
+        _shouldRenderAsSVG(_animatedSVGSupport, disableSvgAnimation) {
+          return _animatedSVGSupport && !disableSvgAnimation;
         }
     });
 </script>

--- a/test/px-spinner-tests.js
+++ b/test/px-spinner-tests.js
@@ -120,18 +120,10 @@ describe('Finished property should hide', function() {
 });
 
 describe('Test size API', function(){
-  let isFirefox;
-  let isSafari;
   let isIE;
-  let isEdge;
-  let isChrome;
 
   before(()=>{
-    isFirefox = typeof InstallTrigger !== 'undefined';
-    isSafari = /constructor/i.test(window.HTMLElement) || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || safari.pushNotification);
     isIE = /*@cc_on!@*/false || !!document.documentMode;
-    isEdge = !isIE && !!window.StyleMedia;
-    isChrome = !!window.chrome && !!window.chrome.webstore;
   });
 
   it('Setting size to 100 should resize px-spinner element', function(done){
@@ -148,7 +140,20 @@ describe('Test size API', function(){
         assert(Polymer.dom(spinnerFixture.root).querySelector('svg').attributes.height, '100');
         done();
       });
-      done();
     }
+  });
+});
+
+describe("Test disableSvgAnimation API", function() {
+  it("Set disableSvgAnimation to true to render as div element", function(done) {
+    const spinnerFixture = fixture("PxSpinner");
+    spinnerFixture.set("disableSvgAnimation", true);
+    flush(function() {
+      expect(Polymer.dom(spinnerFixture.root).querySelector("svg")).to.be.null;
+      expect(
+        Polymer.dom(spinnerFixture.root).querySelector(".spinner-container")
+      ).not.be.null;
+      done();
+    });
   });
 });


### PR DESCRIPTION
* The loading spinner by default is rendered as svg element with animations which will get stuck when large dom manipulation, e.g., let's say it takes 10 seconds to insert elements to the document, the spinner will get stuck in 10 seconds, i.e., no animation.
* Add a property disableSvgAnimation to force px-spinner render as div element.
* Add demo and test case.

@joshsylvester @evanjd @MichaelZaporozhets @sheela-svmx @benjaminliugang pls help review.